### PR TITLE
Use stack ghc instead of ghc in makeplayers.sh.

### DIFF
--- a/gomoku/makeplayers.sh
+++ b/gomoku/makeplayers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd src
-ghc --make MakePlayers.hs  > /dev/null 2>&1
+stack ghc -- --make MakePlayers.hs > /dev/null 2>&1
 ./MakePlayers
 rm MakePlayers
 rm *.hi


### PR DESCRIPTION
I don't have a global ghc install; I just use stack for all my haskell work. Since everyone has to have stack installed to build this project, this should always work. (Making a new pull request from a feature branch because I didn't realize I had to do that.)